### PR TITLE
Support global nginx-proxy container

### DIFF
--- a/src/Site_WP_Command.php
+++ b/src/Site_WP_Command.php
@@ -485,7 +485,10 @@ class Site_WP_Command extends EE_Site_Command {
 		EE::exec( $chown_command );
 
 		$core_download_command = "docker-compose exec --user='www-data' php wp core download --locale='$this->locale' $core_download_arguments";
-		EE::exec( $core_download_command );
+
+		if ( EE::exec( $core_download_command ) ) {
+			EE::error('Unable to download wp core.', false );
+		}
 
 		// TODO: Look for better way to handle mysql healthcheck
 		if ( 'db' === $this->db['host'] ) {

--- a/src/Site_WP_Command.php
+++ b/src/Site_WP_Command.php
@@ -412,7 +412,6 @@ class Site_WP_Command extends EE_Site_Command {
 		try {
 			EE\SiteUtils\create_site_root( $this->site['root'], $this->site['url'] );
 			$this->level = 2;
-			EE\SiteUtils\setup_site_network( $this->site['url'] );
 			$this->maybe_verify_remote_db_connection();
 			$this->level = 3;
 			$this->configure_site_files();

--- a/src/Site_WP_Docker.php
+++ b/src/Site_WP_Docker.php
@@ -18,7 +18,11 @@ class Site_WP_Docker {
 		$base         = [];
 
 		$restart_default = [ 'name' => 'always' ];
-		$network_default = [ 'name' => 'site-network' ];
+		$network_default = [
+			'net' => [
+				[ 'name' => 'site-network' ]
+			]
+		];
 
 		// db configuration.
 		$db['service_name'] = [ 'name' => 'db' ];
@@ -106,8 +110,8 @@ class Site_WP_Docker {
 		];
 		$nginx['networks']    = [
 			'net' => [
-				$network_default,
-				['name' => 'global-network'],
+				[ 'name' => 'site-network' ],
+				[ 'name' => 'global-network' ],
 			]
 		];
 

--- a/src/Site_WP_Docker.php
+++ b/src/Site_WP_Docker.php
@@ -104,8 +104,12 @@ class Site_WP_Docker {
 				'name' => 'io.easyengine.site=${VIRTUAL_HOST}',
 			],
 		];
-		$nginx['networks']    = $network_default;
-		//$nginx['networks']    = [ 'name' => 'global-network' ];
+		$nginx['networks']    = [
+			'net' => [
+				$network_default,
+				['name' => 'global-network'],
+			]
+		];
 
 		// mailhog configuration.
 		$mailhog['service_name'] = [ 'name' => 'mailhog' ];

--- a/src/Site_WP_Docker.php
+++ b/src/Site_WP_Docker.php
@@ -105,6 +105,7 @@ class Site_WP_Docker {
 			],
 		];
 		$nginx['networks']    = $network_default;
+		//$nginx['networks']    = [ 'name' => 'global-network' ];
 
 		// mailhog configuration.
 		$mailhog['service_name'] = [ 'name' => 'mailhog' ];

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -43,7 +43,7 @@ services:
     {{#networks}}
     networks:
     {{#net}}
-      - "{{name}}"
+      - {{name}}
     {{/net}}
     {{/networks}}
 

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -52,4 +52,7 @@ networks:
   site-network:
     external:
       name: ${VIRTUAL_HOST}
+  global-network:
+    external:
+      name: ee-global-network
 {{/network}}

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -42,7 +42,9 @@ services:
     {{/environment}}
     {{#networks}}
     networks:
-      - {{name}}
+    {{#net}}
+      - "{{name}}"
+    {{/net}}
     {{/networks}}
 
 {{/services}}
@@ -50,8 +52,6 @@ services:
 {{#network}}
 networks:
   site-network:
-    external:
-      name: ${VIRTUAL_HOST}
   global-network:
     external:
       name: ee-global-network


### PR DESCRIPTION
Companion PR of - https://github.com/EasyEngine/easyengine/pull/1187
Adds a global network block in docker-compose and connects nginx server to it.

Earlier it used to be that there was a single network per site and nginx-proxy was connected to it.
Now there is a special `ee-global-network` network. All nginx containers of all sites will be connected to it and there will be seperate site-name network in which all containers of same site will connect. 

This PR also fixes an issue that I came up in testing in which site creation was not failing with proper error message when `wp core download` failed. 

Signed-off-by: Kirtan Gajjar <kirtangajjar95@gmail.com>