### PR TITLE
Better return path for wp email

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - TEST_COMMAND=$(echo $TRAVIS_REPO_SLUG | cut -d/ -f 2) # Get command name to be tested
 
 before_script:
+  - sudo curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-$(uname -s)-$(uname -m) -o /usr/local/bin/docker-compose
   - |
     # Remove Xdebug for a huge performance increase:
     if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
@@ -33,3 +34,8 @@ notifications:
   email:
     on_success: never
     on_failure: change
+
+addons:
+  apt:
+    packages:
+      - docker-ce

--- a/src/Site_WP_Command.php
+++ b/src/Site_WP_Command.php
@@ -225,7 +225,7 @@ class Site_WP_Command extends EE_Site_Command {
 			$this->db['port'] = empty( $arg_host_port[1] ) ? '3306' : $arg_host_port[1];
 		}
 
-		$this->site['wp_email'] = EE\Utils\get_flag_value( $assoc_args, 'admin_email', strtolower( 'mail@' . $this->site['url'] ) );
+		$this->site['wp_email'] = EE\Utils\get_flag_value( $assoc_args, 'admin_email', strtolower( 'admin@' . $this->site['url'] ) );
 		$this->skip_install     = EE\Utils\get_flag_value( $assoc_args, 'skip-install' );
 		$this->skip_chk         = EE\Utils\get_flag_value( $assoc_args, 'skip-status-check' );
 		$this->force            = EE\Utils\get_flag_value( $assoc_args, 'force' );
@@ -334,8 +334,12 @@ class Site_WP_Command extends EE_Site_Command {
 			'group_id'      => $process_user['gid'],
 		];
 
+		$php_ini_data = [
+			'admin_email' => $this->site['wp_email'],
+		];
+
 		$env_content     = EE\Utils\mustache_render( SITE_WP_TEMPLATE_ROOT . '/config/.env.mustache', $env_data );
-		$php_ini_content = EE\Utils\mustache_render( SITE_WP_TEMPLATE_ROOT . '/config/php-fpm/php.ini.mustache', [] );
+		$php_ini_content = EE\Utils\mustache_render( SITE_WP_TEMPLATE_ROOT . '/config/php-fpm/php.ini.mustache', $php_ini_data );
 
 		try {
 			$this->fs->dumpFile( $site_docker_yml, $docker_compose_content );
@@ -486,7 +490,7 @@ class Site_WP_Command extends EE_Site_Command {
 
 		$core_download_command = "docker-compose exec --user='www-data' php wp core download --locale='$this->locale' $core_download_arguments";
 
-		if ( EE::exec( $core_download_command ) ) {
+		if ( ! EE::exec( $core_download_command ) ) {
 			EE::error('Unable to download wp core.', false );
 		}
 

--- a/src/Site_WP_Docker.php
+++ b/src/Site_WP_Docker.php
@@ -132,7 +132,12 @@ class Site_WP_Docker {
 				'name' => 'io.easyengine.site=${VIRTUAL_HOST}',
 			],
 		];
-		$mailhog['networks']     = $network_default;
+		$mailhog['networks']     = [
+			'net' => [
+				[ 'name' => 'site-network' ],
+				[ 'name' => 'global-network' ],
+			]
+		];
 
 		// postfix configuration.
 		$postfix['service_name'] = [ 'name' => 'postfix' ];

--- a/templates/config/php-fpm/php.ini.mustache
+++ b/templates/config/php-fpm/php.ini.mustache
@@ -4,4 +4,4 @@ upload_max_filesize = 100M
 post_max_size = 100M
 
 [mail function]
-sendmail_path = /usr/sbin/sendmail -t -i
+sendmail_path = /usr/sbin/sendmail -t -i -f {{admin_email}}

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
 
@@ -52,6 +52,7 @@ services:
 {{#network}}
 networks:
   site-network:
+    name: ${VIRTUAL_HOST}
   global-network:
     external:
       name: ee-global-network


### PR DESCRIPTION
Issue ref - https://github.com/EasyEngine/easyengine/issues/1010
Companion PR - https://github.com/EasyEngine/mailhog-command/pull/2

This PR sets a return path for wordpress and php generated mail.
Also this fixes a minor bug in condition check while checking if wp core has been downloaded or not.

Closes https://github.com/EasyEngine/easyengine/issues/1010