### PR TITLE
Add vendor and site label in site-network

### DIFF
--- a/src/Site_WP_Docker.php
+++ b/src/Site_WP_Docker.php
@@ -179,7 +179,14 @@ class Site_WP_Docker {
 
 		$binding = [
 			'services' => $base,
-			'network'  => true,
+			'network'  => [
+				'networks_labels' => [
+					'label' => [
+						[ 'name' => 'org.label-schema.vendor=EasyEngine' ],
+						[ 'name' => 'io.easyengine.site=${VIRTUAL_HOST}' ],
+					],
+				],
+			],
 		];
 
 		$docker_compose_yml = mustache_render( SITE_WP_TEMPLATE_ROOT . '/docker-compose.mustache', $binding );

--- a/templates/docker-compose.mustache
+++ b/templates/docker-compose.mustache
@@ -52,6 +52,12 @@ services:
 {{#network}}
 networks:
   site-network:
+      {{#networks_labels}}
+      labels:
+      {{#label}}
+       - "{{name}}"
+      {{/label}}
+      {{/networks_labels}}
   global-network:
     external:
       name: ee-global-network


### PR DESCRIPTION
Adds vendor label to the site network.

This adds labels to networks created from docker-compose.

Partial Fix to EasyEngine/easyengine#1189